### PR TITLE
Drop package initialization

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,3 @@ make -j 4 prefix=${PREFIX} MARCH=core2 sysconfigdir=${PREFIX}/etc NO_GIT=1 \
 
 # Configure juliarc to use conda environment
 cp -f "${RECIPE_DIR}/juliarc.jl" "${PREFIX}/etc/julia/juliarc.jl"
-
-# Populate initial package directory
-julia -e "Pkg.init(); Pkg.__init__()"


### PR DESCRIPTION
This does not work correctly as `conda-build` strips out the `.git` directory from `METADATA`. There are no clean fixes for this issue. As we already try to initialize the package directory when Julia starts, this will be handled anyways on the user's machine. In the end, this may be best to avoid having a potentially out-of-date index in the package.